### PR TITLE
fixes Issue #8 - Detected integration that uses deprecated async_get_registry to access device registry - Update HA 2022.6.0 

### DIFF
--- a/custom_components/mila/__init__.py
+++ b/custom_components/mila/__init__.py
@@ -78,8 +78,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     conf_devices = options.get(CONF_DEVICES, data[CONF_DEVICES])
     conf_identifiers = [(DOMAIN, resource_id) for resource_id in conf_devices]
 
-    device_registry = await hass.helpers.device_registry.async_get()
-    # entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    device_registry = await hass.helpers.device_registry.async_get(hass)
     for device_entry in hass.helpers.device_registry.async_entries_for_config_entry(
         device_registry, entry.entry_id
     ):

--- a/custom_components/mila/__init__.py
+++ b/custom_components/mila/__init__.py
@@ -78,7 +78,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     conf_devices = options.get(CONF_DEVICES, data[CONF_DEVICES])
     conf_identifiers = [(DOMAIN, resource_id) for resource_id in conf_devices]
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = await hass.helpers.device_registry.async_get()
     # entity_registry = await hass.helpers.entity_registry.async_get_registry()
     for device_entry in hass.helpers.device_registry.async_entries_for_config_entry(
         device_registry, entry.entry_id

--- a/custom_components/mila/__init__.py
+++ b/custom_components/mila/__init__.py
@@ -78,7 +78,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     conf_devices = options.get(CONF_DEVICES, data[CONF_DEVICES])
     conf_identifiers = [(DOMAIN, resource_id) for resource_id in conf_devices]
 
-    device_registry = await hass.helpers.device_registry.async_get(hass)
+    device_registry = hass.helpers.device_registry.async_get(hass)
     for device_entry in hass.helpers.device_registry.async_entries_for_config_entry(
         device_registry, entry.entry_id
     ):


### PR DESCRIPTION
https://github.com/sanghviharshit/ha-mila/issues/8

async_get_registry has been deprecated as of 2022.6.0

Logger: homeassistant.helpers.frame
Source: helpers/frame.py:103
First occurred: June 3, 2022, 11:29:10 PM (1 occurrences)
Last logged: June 3, 2022, 11:29:10 PM

Detected integration that uses deprecated async_get_registry to access device registry, use async_get instead. Please report issue to the custom component author for mila using this method at custom_components/mila/init.py, line 81: device_registry = await hass.helpers.device_registry.async_get_registry()